### PR TITLE
specify required python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup_args = {
             glob("jupyter_cadquery/icons/*.png"),
         ),
     ],
+    "python_requires": ">=3.6",
     "install_requires": [
         "jupyterlab~=3.0",
         "ipywidgets~=7.6",


### PR DESCRIPTION
This hoists the python version compatibility to something that pip (and therefore `grayskull`) can understand.