### PR TITLE
Install ipykernel into default environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,5 @@ dependencies:
   - pip:
       - jupyter-cadquery==3.5.2
       - cadquery-massembly==1.0.0
+      - ipykernel==6
+      


### PR DESCRIPTION
Install ipykernel into the default cadquery environment.yml.  This will allow the conda environment to be visible as a kernel in jupyter notebook.