### PR TITLE
Fix prod extra cadquery requirement syntax.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_args = {
     ],
     "extras_require": {
         "dev": {"jupyter-packaging", "cookiecutter", "twine", "bumpversion", "black", "pylint", "pyYaml"},
-        "prod": {"cadquery==master"},
+        "prod": {"cadquery @ git+https://github.com/CadQuery/cadquery@master"},
     },
     "packages": find_packages(),
     "scripts": ["jcv", "jcv.cmd"],


### PR DESCRIPTION
Previously this used `==master` as the version specifier which either
matches no versions in old, lax versions of Pip, packaging and other
Python ecosystem tools or else fails parsing altogether in new, strict
versions of those tools. We now use a direct URL VCS requirement to
indicate the tip of the cadquery master branch.

See: https://packaging.python.org/en/latest/specifications/version-specifiers/#direct-references

Fixes #95