### PR TITLE
setup.py -> loosen numpy-quaternion version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,11 @@ setup_args = {
     "description": "An extension to render cadquery objects in JupyterLab via pythreejs",
     "long_description": LONG_DESCRIPTION,
     "include_package_data": True,
-    "python_requires": ">=3.6",
+    "python_requires": ">=3.8",
     "install_requires": [
         "webcolors~=1.12",
         "voila~=0.3.5",
-        "numpy-quaternion==2022.4.1",
+        "numpy-quaternion>=2022.4.1",
         "cad-viewer-widget~=1.4.0",
         "cachetools~=5.2.0",
     ],
@@ -46,9 +46,10 @@ setup_args = {
         "Intended Audience :: Science/Research",
         "Topic :: Multimedia :: Graphics",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 }
 


### PR DESCRIPTION
improves compatibility with newer python versions since numpy-quaternion==2022.4.1 is only built up for py 3.8 through 3.10