### PR TITLE
Fix tessellator normal generation to avoid NoneType error

### DIFF
--- a/jupyter_cadquery/tessellator.py
+++ b/jupyter_cadquery/tessellator.py
@@ -166,7 +166,9 @@ class Tessellator:
                         prop.Normal(u, v, p_buf, n_buf)
                         if n_buf.SquareMagnitude() > 0:
                             n_buf.Normalize()
-                        flat.extend(n_buf.Reverse().Coord() if internal else n_buf.Coord())
+                        if internal:
+                            n_buf.Reverse()
+                        flat.extend(n_buf.Coord())
                     self.normals.extend(flat)
 
                 offset += poly.NbNodes()


### PR DESCRIPTION
I have prepared a fix for the tessellator issue (#97) where an AttributeError is raised due to an
inline call to `n_buf.Reverse().Coord()`. As Reverse() performs an in-place modification and
returns None, chaining it with `.Coord()` leads to the error.

The updated code now calls `n_buf.Reverse()` separately when `internal` is True, and then
retrieves the coordinate values with `n_buf.Coord()`. Here’s the updated snippet for clarity:

    # add normals
    if poly.HasUVNodes():
        prop = BRepGProp_Face(face)
        flat = []
        for i in range(1, poly.NbNodes() + 1):
            u, v = poly.UVNode(i).Coord()
            prop.Normal(u, v, p_buf, n_buf)
            if n_buf.SquareMagnitude() > 0:
                n_buf.Normalize()
            if internal:
                n_buf.Reverse()
            flat.extend(n_buf.Coord())
        self.normals.extend(flat)

This change has been tested locally and resolves the error during the tessellation process.
Could you please review this fix and consider merging it into the official repository?

Thank you for your time and for maintaining this great project!