### PR TITLE
Switch to a more recent version of voila

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dependencies = [
     "webcolors~=1.12",
-    "voila~=0.3.5",
+    "voila~=0.4.0",
     "numpy-quaternion>=2022.4.1",
     "cad-viewer-widget~=1.4.0",
     "cachetools~=5.2.0",


### PR DESCRIPTION
Voila 0.3 depends on nbconvert<7 which is
incompatible with some common packages (e.g. mkdocs-jupyter).